### PR TITLE
Limits, tags, and formatting

### DIFF
--- a/src/main/java/moe/oko/alcazar/Alcazar.java
+++ b/src/main/java/moe/oko/alcazar/Alcazar.java
@@ -1,9 +1,7 @@
 package moe.oko.alcazar;
 
-import me.filoghost.holographicdisplays.api.HolographicDisplaysAPI;
 import moe.oko.alcazar.command.InventoryCommand;
 import moe.oko.alcazar.handler.InventoryHandler;
-import moe.oko.alcazar.handler.DeathMessageHandler;
 import moe.oko.alcazar.command.WarpCommand;
 import moe.oko.alcazar.command.WarpsCommand;
 import moe.oko.alcazar.handler.WarpHandler;
@@ -17,28 +15,23 @@ public class Alcazar extends JavaPlugin {
     private InventoryHandler inventoryHandler;
     private WarpHandler warpHandler;
 
-    private DeathMessageHandler deathMessageHandler;
-    private HolographicDisplaysAPI holographicDisplaysAPI;
-
     @Override
     public void onEnable() {
         this.saveDefaultConfig();
         this.reloadConfig();
-
         config = new AlcazarConfig(this.getConfig());
         db = config.createDB(this);
 
-        inventoryHandler = new InventoryHandler(this, db);
-        warpHandler = new WarpHandler(this, db);
-        deathMessageHandler = new DeathMessageHandler();
-        holographicDisplaysAPI = getServer().getPluginManager().isPluginEnabled("HolographicDisplays")
-                ? HolographicDisplaysAPI.get(this)
-                : null;
+        inventoryHandler = new InventoryHandler(this, db,
+                ((Boolean) config.getConfigValue("inventories", "limitEnabled")),
+                ((Integer) config.getConfigValue("inventories", "limit")));
+        warpHandler = new WarpHandler(this, db,
+                ((Boolean) config.getConfigValue("warps", "limitEnabled")),
+                ((Integer) config.getConfigValue("warps", "limit")));
 
         // Register events
-        getServer().getPluginManager().registerEvents(new PlayerDeathListener(this, deathMessageHandler, holographicDisplaysAPI), this);
+        getServer().getPluginManager().registerEvents(new PlayerDeathListener(), this);
         getServer().getPluginManager().registerEvents(new PlayerJoinListener(config.getWelcomeMessage()), this);
-
         // Register commands
         this.getCommand("inv").setExecutor(new InventoryCommand(inventoryHandler));
         this.getCommand("warp").setExecutor(new WarpCommand(warpHandler));

--- a/src/main/java/moe/oko/alcazar/AlcazarConfig.java
+++ b/src/main/java/moe/oko/alcazar/AlcazarConfig.java
@@ -23,4 +23,7 @@ public class AlcazarConfig {
                 sql.getLong("idleTimeout"),
                 sql.getLong("maxLifetime"));
     }
+    public Object getConfigValue(String section, String value) {
+        return config.getConfigurationSection(section).get(value);
+    }
 }

--- a/src/main/java/moe/oko/alcazar/AlcazarDB.java
+++ b/src/main/java/moe/oko/alcazar/AlcazarDB.java
@@ -4,6 +4,8 @@ import com.google.common.base.Strings;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
 import moe.oko.alcazar.model.DatabaseCredentials;
+import org.bukkit.entity.Player;
+import org.bukkit.Location;
 
 import java.sql.*;
 import java.util.ArrayList;
@@ -45,7 +47,7 @@ public class AlcazarDB {
             connection.prepareStatement("CREATE TABLE IF NOT EXISTS `inventories`" +
                     "(uuid VARCHAR(128), name VARCHAR(64) UNIQUE, si TEXT, sa TEXT);").execute();
             connection.prepareStatement("CREATE TABLE IF NOT EXISTS `warps`" +
-                    "(uuid VARCHAR(128), name VARCHAR(64), location TEXT);").execute();
+                    "(uuid VARCHAR(128), name VARCHAR(64), location TEXT, tag TEXT);").execute();
         } catch (SQLException e) {
             plugin.severe("Failed to initialize SQL tables (permissions issue?)");
             e.printStackTrace();
@@ -94,10 +96,11 @@ public class AlcazarDB {
 
     public boolean addNewWarp(String UUID, String name, String base64Location) {
         try {
-            var ps = connection.prepareStatement("REPLACE INTO warps(uuid, name, location) VALUES (?, ?, ?)");
+            var ps = connection.prepareStatement("REPLACE INTO warps(uuid, name, location, tag) VALUES (?, ?, ?, ?)");
             ps.setString(1, UUID);
             ps.setString(2, name);
             ps.setString(3, base64Location);
+            ps.setString(4, "user");
             ps.execute();
             ps.close();
             return true;
@@ -200,6 +203,26 @@ public class AlcazarDB {
         return null;
     }
 
+    public int getUUIDInvCount(String UUID) {
+        try {
+            var ps = connection.prepareStatement("SELECT uuid FROM inventories");
+            var rs = ps.executeQuery();
+            int toReturn = 0;
+            if (rs.next()) {
+                if (rs.getString("uuid").equals(UUID)) { toReturn++; }
+                while(rs.next()){
+                    if (rs.getString("uuid").equals(UUID)) { toReturn++; }
+                }
+                ps.close();
+                rs.close();
+            }
+            return toReturn;
+        } catch (SQLException e) {
+            plugin.severe("Unable to get the inventory count.");
+        }
+        return 2147483647;
+    }
+
     public List<String> getAllWarpNames(){
         try {
             var ps = connection.prepareStatement("SELECT name FROM warps");
@@ -218,6 +241,46 @@ public class AlcazarDB {
             plugin.severe("Unable to get the warp list.");
         }
         return null;
+    }
+
+    public List<String> getAllWarpTags(){
+        try {
+            var ps = connection.prepareStatement("SELECT tag FROM warps");
+            var rs = ps.executeQuery();
+            if (rs.next()) {
+                List<String> names = new ArrayList<>();
+                names.add(rs.getString("tag"));
+                while(rs.next()){
+                    names.add(rs.getString("tag"));
+                }
+                ps.close();
+                rs.close();
+                return names;
+            }
+        } catch (SQLException e) {
+            plugin.severe("Unable to get the warp tag list.");
+        }
+        return null;
+    }
+
+    public int getUUIDWarpCount(String UUID) {
+        try {
+            var ps = connection.prepareStatement("SELECT uuid FROM warps");
+            var rs = ps.executeQuery();
+            int toReturn = 0;
+            if (rs.next()) {
+                if (rs.getString("uuid").equals(UUID)) { toReturn++; }
+                while(rs.next()){
+                    if (rs.getString("uuid").equals(UUID)) { toReturn++; }
+                }
+                ps.close();
+                rs.close();
+            }
+            return toReturn;
+        } catch (SQLException e) {
+            plugin.severe("Unable to get the warp count.");
+        }
+        return 2147483647;
     }
 
 }

--- a/src/main/java/moe/oko/alcazar/command/InventoryCommand.java
+++ b/src/main/java/moe/oko/alcazar/command/InventoryCommand.java
@@ -1,6 +1,7 @@
 package moe.oko.alcazar.command;
 
 import moe.oko.alcazar.handler.InventoryHandler;
+import net.md_5.bungee.api.ChatColor;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.command.TabExecutor;
@@ -28,32 +29,32 @@ public class InventoryCommand implements TabExecutor {
                 if (args.length != 2)
                     return false;
                 var message = inv.save((Player) sender, args[1])
-                        ? "Saved %s!".formatted(args[1])
-                        : "Unable to save %s".formatted(args[1]);
+                        ? (ChatColor.of("#986de0") + "Saved " + ChatColor.of("#ffffff") + "%s" + ChatColor.of("#986de0") + "!").formatted(args[1])
+                        : (ChatColor.of("#986de0") + "Could not save "  + ChatColor.of("#ffffff") +  "%s".formatted(args[1]));
                 sender.sendMessage(message);
             }
             case "load" -> {
                 if (args.length != 2)
                     return false;
                 var message = inv.load((Player) sender, args[1])
-                        ? "Loaded %s!".formatted(args[1])
-                        : "%s not found.".formatted(args[1]);
+                        ? (ChatColor.of("#986de0") + "Loaded " + ChatColor.of("#ffffff") + "%s" + ChatColor.of("#986de0") + "!").formatted(args[1])
+                        : (ChatColor.of("#ffffff") + "%s" + ChatColor.of("#986de0") + " not found.").formatted(args[1]);
                 sender.sendMessage(message);
             }
             case "remove" -> {
                 if (args.length != 2)
                     return false;
                 var message = inv.remove((Player) sender, args[1])
-                        ? "Removed %s!".formatted(args[1])
-                        : "Could not remove %s".formatted(args[1]);
+                        ? (ChatColor.of("#986de0") + "Removed " + ChatColor.of("#ffffff") + "%s" + ChatColor.of("#986de0") + "!").formatted(args[1])
+                        : (ChatColor.of("#986de0") + "Could not remove "  + ChatColor.of("#ffffff") +  "%s").formatted(args[1]);
                 sender.sendMessage(message);
             }
             case "list" -> {
                 var inventories = inv.list();
                 if (inventories != null)
-                    sender.sendMessage("There are " + inventories.size() + " saved inventories: " + String.join(", ", inventories));
+                    sender.sendMessage(ChatColor.of("#986de0") + "There are " + ChatColor.of("#ffffff") + inventories.size() + ChatColor.of("#986de0") + " saved inventories: " + ChatColor.of("#ffffff") + String.join((ChatColor.of("#986de0") + ", " + ChatColor.of("#ffffff")), inventories));
                 else
-                    sender.sendMessage("There are no saved inventories");
+                    sender.sendMessage(ChatColor.of("#986de0") + "There are no saved inventories.");
             }
             default -> { return false; }
         }

--- a/src/main/java/moe/oko/alcazar/command/WarpCommand.java
+++ b/src/main/java/moe/oko/alcazar/command/WarpCommand.java
@@ -1,6 +1,7 @@
 package moe.oko.alcazar.command;
 
 import moe.oko.alcazar.handler.WarpHandler;
+import net.md_5.bungee.api.ChatColor;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.command.TabExecutor;
@@ -23,8 +24,8 @@ public class WarpCommand implements TabExecutor {
         if (args.length != 1)
             return false;
         var message = handler.load((Player) sender, args[0])
-                ? "Warping to %s!".formatted(args[0])
-                : "%s not found.".formatted(args[0]);
+                ? (ChatColor.of("#986de0") + "Warping to " + ChatColor.of("#ffffff") + "%s" + ChatColor.of("#986de0") + "!").formatted(args[0])
+                : (ChatColor.of("#ffffff") + "%s" + ChatColor.of("#986de0") + " not found.").formatted(args[0]);
         sender.sendMessage(message);
 
         return true;

--- a/src/main/java/moe/oko/alcazar/command/WarpsCommand.java
+++ b/src/main/java/moe/oko/alcazar/command/WarpsCommand.java
@@ -1,6 +1,7 @@
 package moe.oko.alcazar.command;
 
 import moe.oko.alcazar.handler.WarpHandler;
+import net.md_5.bungee.api.ChatColor;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.command.TabExecutor;
@@ -28,24 +29,34 @@ public class WarpsCommand implements TabExecutor {
                 if (args.length != 2)
                     return false;
                 var message = handler.save((Player) sender, args[1])
-                        ? "Saved %s!".formatted(args[1])
-                        : "Unable to save %s".formatted(args[1]);
+                        ? (ChatColor.of("#986de0") + "Saved " + ChatColor.of("#ffffff") + "%s" + ChatColor.of("#986de0") + "!").formatted(args[1])
+                        : (ChatColor.of("#986de0") + "Could not save "  + ChatColor.of("#ffffff") +  "%s".formatted(args[1]));
                 sender.sendMessage(message);
             }
             case "remove" -> {
                 if (args.length != 2)
                     return false;
                 var message = handler.remove((Player) sender, args[1])
-                        ? "Removed %s!".formatted(args[1])
-                        : "Could not remove %s".formatted(args[1]);
+                        ? (ChatColor.of("#986de0") + "Removed " + ChatColor.of("#ffffff") + "%s" + ChatColor.of("#986de0") + "!").formatted(args[1])
+                        : (ChatColor.of("#986de0") + "Could not remove "  + ChatColor.of("#ffffff") +  "%s").formatted(args[1]);
                 sender.sendMessage(message);
             }
             case "list" -> {
                 var warps = handler.list();
-                if (warps != null)
-                    sender.sendMessage("There are " + warps.size() + " saved warps: " + String.join(", ", warps));
-                else
-                    sender.sendMessage("There are no saved inventories");
+                var tags = handler.tagList();
+                if (warps != null) {
+                    sender.sendMessage(ChatColor.of("#986de0") + "There are " + warps.size() + " saved warps:");
+                    for (int i = 0; i < warps.size(); i++) {
+                        if (tags.get(i).toString().equals("user")) {
+                            sender.sendMessage("   " + ChatColor.of("#ffffff") + warps.get(i) + " (§b" + tags.get(i) + ChatColor.of("#ffffff") + ")");
+                        } else {
+                            sender.sendMessage("   " + ChatColor.of("#ffffff") + warps.get(i) + " (§d" + tags.get(i) + ChatColor.of("#ffffff") + ")");
+                        }
+                    }
+                }
+                else {
+                    sender.sendMessage(ChatColor.of("#986de0") + "There are no saved warps.");
+                }
             }
             default -> { return false; }
         }


### PR DESCRIPTION
- Implemented configurable per-user inventory and warp limits. 
- Implemented warp tags (default is "user"). 
- Made formatting prettier across the board.

Accidentally used a dated version of Alcazar.java missing some stuff on PlayerDeathHandler and HolographicDisplays, sorry. New code should be fine though.

Example config.yml formatting for limits is:
```java
inventories:
  limitEnabled: true
  limit: 5
warps:
  limitEnabled: true
  limit: 3